### PR TITLE
Add doc pages for new Keysight instruments

### DIFF
--- a/doc/source/instruments/bench.keysight.e5071c.rst
+++ b/doc/source/instruments/bench.keysight.e5071c.rst
@@ -1,0 +1,7 @@
+Keysight E5071C ENA Network Analyzer
+====================================
+
+.. automodule:: bench.keysight.e5071c
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/source/instruments/bench.keysight.e8257d.rst
+++ b/doc/source/instruments/bench.keysight.e8257d.rst
@@ -1,0 +1,7 @@
+Keysight E8257D PSG Analog Signal Generator
+===========================================
+
+.. automodule:: bench.keysight.e8257d
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/source/instruments/bench.keysight.n5182b.rst
+++ b/doc/source/instruments/bench.keysight.n5182b.rst
@@ -1,0 +1,7 @@
+Keysight N5182B MXG Vector Signal Generator
+===========================================
+
+.. automodule:: bench.keysight.n5182b
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/source/instruments/bench.keysight.n5232a.rst
+++ b/doc/source/instruments/bench.keysight.n5232a.rst
@@ -1,0 +1,7 @@
+Keysight N5232A PNA-L Network Analyzer
+======================================
+
+.. automodule:: bench.keysight.n5232a
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/source/instruments/bench.keysight.n9020b.rst
+++ b/doc/source/instruments/bench.keysight.n9020b.rst
@@ -1,0 +1,7 @@
+Keysight N9020B MXA Signal Analyzer
+===================================
+
+.. automodule:: bench.keysight.n9020b
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/source/instruments/bench.keysight.n9030b.rst
+++ b/doc/source/instruments/bench.keysight.n9030b.rst
@@ -1,0 +1,7 @@
+Keysight N9030B PXA Signal Analyzer
+===================================
+
+.. automodule:: bench.keysight.n9030b
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/source/instruments/index.md
+++ b/doc/source/instruments/index.md
@@ -13,6 +13,12 @@ bench.hittite.hmct2220.rst
 :caption: Keysight
 
 bench.keysight.e36233a.rst
+bench.keysight.e5071c.rst
+bench.keysight.e8257d.rst
+bench.keysight.n5182b.rst
+bench.keysight.n5232a.rst
+bench.keysight.n9020b.rst
+bench.keysight.n9030b.rst
 bench.keysight.n9040b.rst
 
 ```


### PR DESCRIPTION
## Summary

- Adds Sphinx automodule pages for the 6 Keysight instruments added in #5: `N5182B`, `E8257D`, `N9020B`, `N9030B`, `N5232A`, `E5071C`.
- Lists them under the Keysight caption in `doc/source/instruments/index.md`.

These were on the #5 branch but didn't make it into the merged commits, so the published doc still only shows `E36233A` and `N9040B` under Keysight.

## Test plan

- [x] `Documentation Tests` workflow renders the new pages without warnings.